### PR TITLE
Favorite Ride properly set to N/A when importing RCT1/CF S4s

### DIFF
--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1473,8 +1473,18 @@ private:
         dst->pathfind_goal.z = 0xFF;
         dst->pathfind_goal.direction = 0xFF;
 
-        dst->favourite_ride = src->favourite_ride;
-        dst->favourite_ride_rating = src->favourite_ride_rating;
+		// It seems guests' favorite rides either wasn't a feature
+		// or wasn't saved prior to Loopy Landscapes
+		if (_gameVersion == FILE_VERSION_RCT1_LL)
+		{
+			dst->favourite_ride = src->favourite_ride;
+			dst->favourite_ride_rating = src->favourite_ride_rating;
+		}
+		else
+		{
+			dst->favourite_ride = 0xFF;
+			dst->favourite_ride_rating = 0;
+		}
 
         dst->item_standard_flags = src->item_standard_flags;
 


### PR DESCRIPTION
It seems guests' favorite rides either wasn't a feature or wasn't saved
prior to Loopy Landscapes.

So now favorite rides are set to N/A (0xFF)
when importing S4's with a non-LL game version.